### PR TITLE
fix issue #627

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -397,7 +397,20 @@ class BinLogStreamReader(object):
                 # valid, if not, get the current position from master
                 if self.log_file is None or self.log_pos is None:
                     cur = self._stream_connection.cursor()
-                    cur.execute("SHOW MASTER STATUS")
+
+                    if self.mysql_version == (0, 0, 0):
+                        cur.execute("SELECT VERSION()")
+                        version = cur.fetchone()
+                        if version is None: raise
+                        self.mysql_version = tuple(
+                            [int(x) for x in version[:1][0].split(".")[:3]]
+                        )
+                        
+                    if self.mysql_version >= (8, 4, 0):
+                        cur.execute("SHOW BINARY LOG STATUS")
+                    else:
+                        cur.execute("SHOW MASTER STATUS")
+
                     master_status = cur.fetchone()
                     if master_status is None:
                         raise BinLogNotEnabled()


### PR DESCRIPTION
Tihs is a simple workaround but like the issue states - could there be another other parts of the lib  affected by MASTER not being supported anymore in newer mysql versions

### Description
<!--Please describe your pull request as detailed as possible. Include information on what problem it solves, what features it adds, etc.-->

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify below)

### Checklist
- [ ] I have read and understood the [CONTRIBUTING.md](https://github.com/julien-duponchelle/python-mysql-replication/blob/main/CONTRIBUTING.md) document.
- [ ] I have checked there aren't any other open [Pull Requests](https://github.com/julien-duponchelle/python-mysql-replication/pulls) for the desired changes.
- [ ] This PR resolves an issue #[Issue Number Here].

### Tests
- [ ] All tests have passed.
- [ ] New tests have been added to cover the changes. (describe below if applicable).

### Additional Information
<!--If there's any additional information or context you'd like to provide for this PR, such as screenshots, reference documents, or release notes, please include them here.-->
